### PR TITLE
Rename cheat sheets to protocols

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ We are currently in the pilot phase of the project, with the following short-ter
 - summarize the occurrence of bat calls throughout summer to fall
 - based on bat occurrence, try trapping bats to identify species
 
-## Cheat sheets
-Follow the steps outlined in the cheat sheets for lab preparation, field deployment/recovery, and data uploading:
+## Protocols
+Follow the steps outlined in the protocols for lab preparation, field deployment/recovery, and data uploading:
 - [01_lab.md](./cheat_sheets/01_lab.md)
 - [02_field.md](./cheat_sheets/02_field.md)
 - [03_upload.md](./cheat_sheets/03_upload.md)

--- a/protocol/01_lab.md
+++ b/protocol/01_lab.md
@@ -1,4 +1,4 @@
-# Lab preparation cheat sheet
+# Lab preparation protocol
 
 
 ## Initiate GitHub field record entries

--- a/protocol/02_field.md
+++ b/protocol/02_field.md
@@ -1,4 +1,4 @@
-# Field deployment/recovery cheat sheet
+# Field deployment/recovery protocol
 
 ## Personnel
 

--- a/protocol/03_upload.md
+++ b/protocol/03_upload.md
@@ -1,4 +1,4 @@
-# Data uploading cheat sheet
+# Data uploading protocol
 
 
 ## Set up data uploading


### PR DESCRIPTION
This PR:
- change `cheat sheets` to `protocol`
- fixes some typos and redundancy in the protocol