### PR TITLE
Add "T" to datetime string

### DIFF
--- a/field_records/ubna_2022b.md
+++ b/field_records/ubna_2022b.md
@@ -31,6 +31,6 @@ Date and Time deployed (local) | Date and Time recovered (local) | AudioMoth # |
  =================================================================================
  ====== LINE BELOW TO COPY-PASTE:  FILL IN BEFORE AND AFTER DEPLOYMENT ===========
  =================================================================================
-DEPLOY_YYYY-MM-DDTHH:MM:SS | RECOVER_YYYY-MM-DDTHH:MM:SS | UNIT_NUM | SD_NUM | LOCATION | LAT_XX.XXXXXX | LON_XX.XXXXXX | SAMPLING_RATE | FILTER | GAIN | AMP_THRESHOLD | VOLT_START | VOLT_END | DEPLOY_PERSON | SCRIBE_PERSON | UPLOAD_PERSON | UPLOAD_FOLDER | NOTES
+DEPLOY_YYYY-MM-DDThh:mm:ss | RECOVER_YYYY-MM-DDThh:mm:ss | UNIT_NUM | SD_NUM | LOCATION | LAT_XX.XXXXXX | LON_XX.XXXXXX | SAMPLING_RATE | FILTER | GAIN | AMP_THRESHOLD | VOLT_START | VOLT_END | DEPLOY_PERSON | SCRIBE_PERSON | UPLOAD_PERSON | UPLOAD_FOLDER | NOTES
  =================================================================================
  -->


### PR DESCRIPTION
@aditya-uw @Jgsachen : I propose to change the datetime format by adding a "T" in the middle of the year and date (e.g., `2022-07-19T15:15:00`). This is a standard format (see [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601)) and probably more error-proof because of the T in the middle of otherwise just a string of numbers. It's also the standard printout from libraries like `xarray`.