### PR TITLE
Readability + Typo fix + Lat/Lon details

### DIFF
--- a/field_records/ubna_2022b.md
+++ b/field_records/ubna_2022b.md
@@ -152,7 +152,7 @@ NOT DEPLOYED AT LOCATION | - | F | - | Fallen Tree | - | - | - | - | - | - | - |
 2022-10-13T16:50:00 | 2022-10-17T10:03:00 | A | 007 | Telephone Field | No Valid Info | No Valid Info | 192000 | Medium | None | None | 4.198 | 3.568 | JS | JS | AK | recover-20221017 | IKEA
 2022-10-13T17:03:00 | 2022-10-17T10:20:00 | B | 008 | Foliage | No Valid Info | No Valid Info | 192000 | Medium | None | None | 4.152 | 3.498 | AK | JS | AK | recover-20221017 | Panasonic
 2022-10-13T17:15:00 | 2022-10-17T10:28:00 | C | 009 | Central Pond | 47° 39' 17.010'' N | 122° 17' 34.302'' W | 192000 | Medium | None | None | 4.174 | 3.741 | JS | JS | AK | recover-20221017 | IKEA
-2022-10-13T17:28:00 | 2022-10-17T10:37:00 | D | 010 | Carp Pond | 47° 39' 17.058'' N | 122° 17' 42.162'' W | 192000 | Medium | None | None | 4.166 | 3.790 | JS | JS | AK | recover-20221013 | IKEA
+2022-10-13T17:28:00 | 2022-10-17T10:37:00 | D | 010 | Carp Pond | 47° 39' 17.058'' N | 122° 17' 42.162'' W | 192000 | Medium | None | None | 4.166 | 3.790 | JS | JS | AK | recover-20221017 | IKEA
 2022-10-13T17:45:00 | 2022-10-17T10:49:00 | E | 011 | Fallen Tree | 47° 39' 23.082'' N | 122° 17' 33.918'' W | 192000 | Medium | None | None | 4.137 | 3.513 | AK | JS | AK | recover-20221017 | Panasonic
 2022-10-13T17:57:00 | 2022-10-17T10:58:00 | F | 012 | Opposite Central Pond | 47° 39' 19.740'' N | 122° 17' 35.538'' W | 192000 | Medium | None | None | 4.161 | 3.581 | AK | JS | AK | recover-20221017 | Panasonic
 2022-10-17T10:08:00 | 2022-10-27T12:20:00 | A | 001 | Telephone Field | No Valid Info | No Valid Info | 192000 | Medium | None | None | 4.134 | 3.870 | JS | JS | AK | recover-20221027 | IKEA


### PR DESCRIPTION
@leewujung I made these changes in my own fork a week ago but accidentally did not make the PR to the repo. I noticed and fixed a few things:
1) The use of commas in the "Notes" was making it hard for Pandas to convert into Dataframe because commas are used as the delimiter. I changed the commas to semicolons.

2) The `recover-DATE` for recordings recovered on 10-06-2022 were set as `recover-20221003`. I changed those to `recover-20221006`.

3) I also added in lat/lon details for the most recent recordings because I merged last deployment's branch before adding those in.

4) I added a note that the SD card had popped out of the recorder for `recover-20220926, SD# 004`. This was written in our field journal but I did not add it. I found out when I looked to see where the recordings are and found none.

